### PR TITLE
fix: avoid race condition on permissions

### DIFF
--- a/src/skill.ts
+++ b/src/skill.ts
@@ -150,6 +150,9 @@ export class Skill extends SkillBase {
     // Set resource skillId to Alexa Skill resource Skill ID.
     this.skillId = resource.ref;
 
+    // Explicit dependency to IAM Policy (which is part of the Role construct) to prevent race condition
+    resource.node.addDependency(askResourceRole);
+
     // This section is only necessary if a Lambda Function was supplied in the props.
     if (props.endpointLambdaFunction) {
       // Create placeholder Lambda Permission to allow Alexa Skill to pass endpoint validation.


### PR DESCRIPTION
The policy and the Alexa skill are created at the same time, although the skill needs permission defined in the policy to succeed. This fix adds an explicit dependency.