### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: npx projen build
       - name: Check for changes
         id: git_diff
-        run: git diff --exit-code || echo "::set-output name=has_changes::true"
+        run: git diff --exit-code || echo "has_changes=true" >> "$GITHUB_OUTPUT"
       - if: steps.git_diff.outputs.has_changes
         name: Commit and push changes (if changed)
         run: 'git add . && git commit -m "chore: self mutation" && git push origin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: npx projen release
       - name: Check for new commits
         id: git_remote
-        run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{
+        run: echo latest_commit="$(git ls-remote origin -h ${{ >> "$GITHUB_OUTPUT"
           github.ref }} | cut -f1)"
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -32,8 +32,8 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "::set-output name=conclusion::success" || echo
-          "::set-output name=conclusion::failure"
+        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
+          "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter